### PR TITLE
feat: allow warn and other events to show

### DIFF
--- a/src/devtools/devtools.css
+++ b/src/devtools/devtools.css
@@ -111,6 +111,11 @@ tr{
     border-radius: 2px;
 }
 
+tbody > tr {
+    background-color: #f2b4a3;
+    color: black;
+}
+
 .origin, .window-load, .dom-content-loaded, .navigate {
     background-color: #f2b4a3;
     color: black;

--- a/src/devtools/devtools.html
+++ b/src/devtools/devtools.html
@@ -33,6 +33,7 @@
                     <input type="checkbox" id="api" value="api" checked><label for="api">Agent API</label>
                     <input type="checkbox" id="drain" value="drain" checked><label for="drain">Drain</label>
                     <input type="checkbox" id="long-task" value="long-task" checked><label for="long-task">Long Task</label>
+                    <input type="checkbox" id="warn" value="warn" checked><label for="warn">Warn</label>
                 </div>
                 <hr data-hideable class="hidden" />
                 <div data-hideable class="hidden">
@@ -44,19 +45,20 @@
                 <hr data-hideable class="hidden"/>
                 <div data-hideable class="hidden">
                     <div class="bold">Feature</div>
-                    <input type="checkbox" id="ajax" value="ajax" checked><label for="ajax">AjaxRequest (<span id="ajax-count">0</span>)</label>
-                    <input type="checkbox" id="generic_events" value="generic_events" checked><label for="generic_events">Generic Events (<span id="generic_events-count">0</span>)</label>
-                    <input type="checkbox" id="jserrors" value="jserrors" checked><label for="jserrors">JavaScriptError (<span id="jserrors-count">0</span>)</label>
-                    <input type="checkbox" id="logging" value="logging" checked><label for="logging">Log (<span id="logging-count">0</span>)</label>
-                    <input type="checkbox" id="metrics" value="metrics" checked><label for="metrics">Metrics (<span id="metrics-count">0</span>)</label>
-                    <input type="checkbox" id="page_view_event" value="page_view_event" checked><label for="page_view_event">PageView (<span id="page_view_event-count">0</span>)</label>
-                    <input type="checkbox" id="page_view_timing" value="page_view_timing" checked><label for="page_view_timing">PageViewTiming (<span id="page_view_timing-count">0</span>)</label>
-                    <input type="checkbox" id="session_replay" value="session_replay" checked><label for="session_replay">Session Replay (<span id="session_replay-count">0</span>)</label>
-                    <input type="checkbox" id="session_trace" value="session_trace" checked><label for="session_trace">Session Trace (<span id="session_trace-count">0</span>)</label>
-                    <input type="checkbox" id="soft_navigations" value="soft_navigations" checked><label for="soft_navigations">Soft Navigations (<span id="soft_navigations-count">0</span>)</label>
-                    <input type="checkbox" id="spa" value="spa" checked><label for="spa">SPA (<span id="spa-count">0</span>)</label>
-                    <input type="checkbox" id="shared_aggregator" value="shared_aggregator" checked><label for="shared_aggregator">Shared Aggregator (<span id="shared_aggregator-count">0</span>)</label>
-                    <input type="checkbox" id="session" value="session" checked><label for="session">Session (<span id="session-count">0</span>)</label>
+                    <input type="checkbox" id="ajax" value="ajax" checked><label for="ajax">AjaxRequest</label>
+                    <input type="checkbox" id="generic_events" value="generic_events" checked><label for="generic_events">Generic Events</label>
+                    <input type="checkbox" id="jserrors" value="jserrors" checked><label for="jserrors">JavaScriptError</label>
+                    <input type="checkbox" id="logging" value="logging" checked><label for="logging">Log</label>
+                    <input type="checkbox" id="metrics" value="metrics" checked><label for="metrics">Metrics</label>
+                    <input type="checkbox" id="page_view_event" value="page_view_event" checked><label for="page_view_event">PageView</label>
+                    <input type="checkbox" id="page_view_timing" value="page_view_timing" checked><label for="page_view_timing">PageViewTiming</label>
+                    <input type="checkbox" id="session_replay" value="session_replay" checked><label for="session_replay">Session Replay</label>
+                    <input type="checkbox" id="session_trace" value="session_trace" checked><label for="session_trace">Session Trace</label>
+                    <input type="checkbox" id="soft_navigations" value="soft_navigations" checked><label for="soft_navigations">Soft Navigations</label>
+                    <input type="checkbox" id="spa" value="spa" checked><label for="spa">SPA</label>
+                    <input type="checkbox" id="shared_aggregator" value="shared_aggregator" checked><label for="shared_aggregator">Shared Aggregator</label>
+                    <input type="checkbox" id="session" value="session" checked><label for="session">Session</label>
+                    <input type="checkbox" id="warn-feature" value="warn-feature" checked><label for="warn-feature">Warn</label>
                 </div>
                 <hr data-hideable class="hidden"/>
                 <div data-hideable class="hidden">

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -32,6 +32,7 @@ const filters = {
     spa: true,
     shared_aggregator: true,
     session: true,
+    warn: true,
     // attributes
     timestamp: true,
     name: true,
@@ -162,7 +163,7 @@ const debouncedRender = debounce(render, 1000)
 function appendMessage(message) {
     document.querySelector('#no-content').classList.toggle('hidden', !!data.length)
     document.querySelector('#loading').classList.toggle('hidden', !data.length)
-    if (!message.event || !filters[message.event.name] || !filters[message.event.type] || !filters[message.event.feature]) return
+    if (!message.event || filters[message.event.name] === false || filters[message.event.type] === false || filters[message.event.feature] === false) return
     if (!!textSearch && JSON.stringify(message).indexOf(textSearch) === -1) return
     const timestamp = filters.timestamp ? `<td class="x-small-cell">${message.timeStamp}</td>` : '</td><td>'
     const name = filters.name ? `<td class="small-cell">${message.event.name}</td>` : '</td><td>'


### PR DESCRIPTION
Update the extension to allow warn events as well as any other future events to show (they just wont be filterable, always on)